### PR TITLE
Fix unboxing issue in OptionEncoder

### DIFF
--- a/src/main/scala/io/github/pashashiz/spark_encoders/Primitive.scala
+++ b/src/main/scala/io/github/pashashiz/spark_encoders/Primitive.scala
@@ -5,10 +5,17 @@ import org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator
 import org.apache.spark.sql.catalyst.expressions.objects.{Invoke, StaticInvoke}
 import org.apache.spark.sql.types.{ObjectType, _}
 
+
 object Primitive {
 
   def isPrimitive(dt: DataType): Boolean =
     CodeGenerator.isPrimitiveType(dt)
+
+  def isUnboxable(dt: DataType): Boolean = dt match {
+    case BooleanType | ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType => true
+    case _: DecimalType => false
+    case _ => false
+  }
 
   def getClass(dt: DataType): Class[_] =
     CodeGenerator.javaClass(dt)
@@ -28,7 +35,7 @@ object Primitive {
 
   def unbox(expr: Expression, dataType: DataType): Expression = {
     val method =
-      if (isPrimitive(dataType) && dataType != TimestampType)
+      if (isUnboxable(dataType))
         Some(s"${CodeGenerator.javaType(dataType)}Value")
       else
         None

--- a/src/main/scala/io/github/pashashiz/spark_encoders/Primitive.scala
+++ b/src/main/scala/io/github/pashashiz/spark_encoders/Primitive.scala
@@ -13,7 +13,6 @@ object Primitive {
 
   def isUnboxable(dt: DataType): Boolean = dt match {
     case BooleanType | ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType => true
-    case _: DecimalType => false
     case _ => false
   }
 
@@ -33,6 +32,12 @@ object Primitive {
     }
   }
 
+  /** For boxed Java primitive types, we can safely take the boxed value.
+   *  However, we need to take special care with Spark data types that map
+   *  to Java primitives. For example, [[java.time.Instant]] maps to [[org.apache.spark.sql.types.TimestampType]]
+   *  which maps to Java primitive long. We can't unbox these, but Spark's
+   *  [[org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator.isPrimitiveType]] would return true.
+   */
   def unbox(expr: Expression, dataType: DataType): Expression = {
     val method =
       if (isUnboxable(dataType))

--- a/src/main/scala/io/github/pashashiz/spark_encoders/Primitive.scala
+++ b/src/main/scala/io/github/pashashiz/spark_encoders/Primitive.scala
@@ -28,7 +28,7 @@ object Primitive {
 
   def unbox(expr: Expression, dataType: DataType): Expression = {
     val method =
-      if (isPrimitive(dataType))
+      if (isPrimitive(dataType) && dataType != TimestampType)
         Some(s"${CodeGenerator.javaType(dataType)}Value")
       else
         None

--- a/src/test/scala/io/github/pashashiz/spark_encoders/OptionEncoderSpec.scala
+++ b/src/test/scala/io/github/pashashiz/spark_encoders/OptionEncoderSpec.scala
@@ -1,0 +1,166 @@
+package io.github.pashashiz.spark_encoders
+
+import java.math.{BigDecimal => JBigDecimal, BigInteger => JBigInt}
+import java.sql.{Date, Timestamp}
+import java.time._
+import java.util.UUID
+import scala.concurrent.duration.{FiniteDuration, DurationInt}
+import scala.util.Random
+
+class OptionEncoderSpec extends SparkAnyWordSpec() with TypedEncoderMatchers with TypedEncoderImplicits {
+
+  "OptionEncoder" when {
+
+    "used with primitive types" should {
+
+      "support String wrapped in Option" in {
+        Option("Hey!") should haveTypedEncoder[Option[String]]()
+        Option("") should haveTypedEncoder[Option[String]]()
+        Option(Random.alphanumeric.take(10000).mkString("")) should haveTypedEncoder[Option[String]]()
+        Option.empty[String] should haveTypedEncoder[Option[String]]()
+      }
+
+      "support Boolean wrapped in Option" in {
+        Option(true) should haveTypedEncoder[Option[Boolean]]()
+        Option(false) should haveTypedEncoder[Option[Boolean]]()
+        Option.empty[Boolean] should haveTypedEncoder[Option[Boolean]]()
+      }
+
+      "support Byte wrapped in Option" in {
+        Option(Byte.MinValue) should haveTypedEncoder[Option[Byte]]()
+        Option((-35).toByte) should haveTypedEncoder[Option[Byte]]()
+        Option(0.toByte) should haveTypedEncoder[Option[Byte]]()
+        Option(35.toByte) should haveTypedEncoder[Option[Byte]]()
+        Option(Byte.MaxValue) should haveTypedEncoder[Option[Byte]]()
+        Option.empty[Byte] should haveTypedEncoder[Option[Byte]]()
+      }
+
+      "support Short wrapped in Option" in {
+        Option(Short.MinValue) should haveTypedEncoder[Option[Short]]()
+        Option((-543).toShort) should haveTypedEncoder[Option[Short]]()
+        Option(0.toShort) should haveTypedEncoder[Option[Short]]()
+        Option(543.toShort) should haveTypedEncoder[Option[Short]]()
+        Option(Short.MaxValue) should haveTypedEncoder[Option[Short]]()
+        Option.empty[Short] should haveTypedEncoder[Option[Short]]()
+      }
+
+      "support Int wrapped in Option" in {
+        Option(Int.MinValue) should haveTypedEncoder[Option[Int]]()
+        Option(-13656545) should haveTypedEncoder[Option[Int]]()
+        Option(0) should haveTypedEncoder[Option[Int]]()
+        Option(13656545) should haveTypedEncoder[Option[Int]]()
+        Option(Int.MaxValue) should haveTypedEncoder[Option[Int]]()
+        Option.empty[Int] should haveTypedEncoder[Option[Int]]()
+      }
+
+      "support Long wrapped in Option" in {
+        Option(Long.MinValue) should haveTypedEncoder[Option[Long]]()
+        Option(-1343095043994444L) should haveTypedEncoder[Option[Long]]()
+        Option(0L) should haveTypedEncoder[Option[Long]]()
+        Option(1343095043994444L) should haveTypedEncoder[Option[Long]]()
+        Option(Long.MaxValue) should haveTypedEncoder[Option[Long]]()
+        Option.empty[Long] should haveTypedEncoder[Option[Long]]()
+      }
+
+      "support Float wrapped in Option" in {
+        Option(Float.MinValue) should haveTypedEncoder[Option[Float]]()
+        Option(-34.643f) should haveTypedEncoder[Option[Float]]()
+        Option(-0.0f) should haveTypedEncoder[Option[Float]]()
+        Option(34.643f) should haveTypedEncoder[Option[Float]]()
+        Option(Float.MaxValue) should haveTypedEncoder[Option[Float]]()
+        Option.empty[Float] should haveTypedEncoder[Option[Float]]()
+      }
+
+      "support Double wrapped in Option" in {
+        Option(Double.MinValue) should haveTypedEncoder[Option[Double]]()
+        Option(-34.643) should haveTypedEncoder[Option[Double]]()
+        Option(0.0) should haveTypedEncoder[Option[Double]]()
+        Option(34.643) should haveTypedEncoder[Option[Double]]()
+        Option(Double.MaxValue) should haveTypedEncoder[Option[Double]]()
+        Option.empty[Double] should haveTypedEncoder[Option[Double]]()
+      }
+
+      "support BigDecimal wrapped in Option" in {
+        Option(BigDecimal("1943784783.989793879489340000")) should haveTypedEncoder[Option[BigDecimal]]()
+        Option(BigDecimal("19437847830000000000000000000000.989793879489340000")) should haveTypedEncoder[Option[BigDecimal]]()
+        Option.empty[BigDecimal] should haveTypedEncoder[Option[BigDecimal]]()
+      }
+
+      "support Java BigDecimal wrapped in Option" in {
+        Option(new JBigDecimal("1943784783.989793879489340000")) should haveTypedEncoder[Option[JBigDecimal]]()
+        Option(new JBigDecimal("19437847830000000000000000000000.989793879489340000")) should haveTypedEncoder[Option[JBigDecimal]]()
+        Option.empty[JBigDecimal] should haveTypedEncoder[Option[JBigDecimal]]()
+      }
+
+      "support BigInt wrapped in Option" in {
+        Option(BigInt("1943784783")) should haveTypedEncoder[Option[BigInt]]()
+        Option(BigInt("19437847830000000000000000000000")) should haveTypedEncoder[Option[BigInt]]()
+        Option.empty[BigInt] should haveTypedEncoder[Option[BigInt]]()
+      }
+
+      "support Java BigInteger wrapped in Option" in {
+        Option(new JBigInt("1943784783")) should haveTypedEncoder[Option[JBigInt]]()
+        Option(new JBigInt("19437847830000000000000000000000")) should haveTypedEncoder[Option[JBigInt]]()
+        Option.empty[JBigInt] should haveTypedEncoder[Option[JBigInt]]()
+      }
+
+      "support UUID wrapped in Option" in {
+        Option(UUID.fromString("e5ee0a5d-75f5-42de-adbf-c9f19df26475")) should haveTypedEncoder[Option[UUID]]()
+        Option.empty[UUID] should haveTypedEncoder[Option[UUID]]()
+      }
+    }
+
+    "used with time types" should {
+
+      "support Timestamp wrapped in Option" in {
+        Option(Timestamp.valueOf("2025-04-02 19:09:42.657")) should haveTypedEncoder[Option[Timestamp]]()
+        Option.empty[Timestamp] should haveTypedEncoder[Option[Timestamp]]()
+      }
+
+      "support Instant wrapped in Option" in {
+        Option(Instant.parse("2025-04-02T19:09:42.657Z")) should haveTypedEncoder[Option[Instant]]()
+        Option.empty[Instant] should haveTypedEncoder[Option[Instant]]()
+      }
+
+      "support LocalDateTime wrapped in Option" in {
+        Option(LocalDateTime.parse("2025-04-02T19:09:42.657")) should haveTypedEncoder[Option[LocalDateTime]]()
+        Option.empty[LocalDateTime] should haveTypedEncoder[Option[LocalDateTime]]()
+      }
+
+      "support Date wrapped in Option" in {
+        Option(Date.valueOf("2025-04-02")) should haveTypedEncoder[Option[Date]]()
+        Option.empty[Date] should haveTypedEncoder[Option[Date]]()
+      }
+
+      "support LocalDate wrapped in Option" in {
+        Option(LocalDate.parse("2025-04-02")) should haveTypedEncoder[Option[LocalDate]]()
+        Option.empty[LocalDate] should haveTypedEncoder[Option[LocalDate]]()
+      }
+
+      "support OffsetDateTime wrapped in Option" in {
+        Option(OffsetDateTime.parse("2025-04-02T22:08:01.855+03:00")) should haveTypedEncoder[Option[OffsetDateTime]]()
+        Option.empty[OffsetDateTime] should haveTypedEncoder[Option[OffsetDateTime]]()
+      }
+
+      "support ZonedDateTime wrapped in Option" in {
+        Option(ZonedDateTime.parse("2025-04-02T22:19:30.498+03:00[Europe/Kiev]")) should haveTypedEncoder[Option[ZonedDateTime]]()
+        Option.empty[ZonedDateTime] should haveTypedEncoder[Option[ZonedDateTime]]()
+      }
+
+      "support Java Duration wrapped in Option" in {
+        Option(Duration.ofHours(15)) should haveTypedEncoder[Option[Duration]]()
+        Option.empty[Duration] should haveTypedEncoder[Option[Duration]]()
+      }
+
+      "support FiniteDuration wrapped in Option" in {
+        Option(15.hours) should haveTypedEncoder[Option[FiniteDuration]]()
+        Option.empty[FiniteDuration] should haveTypedEncoder[Option[FiniteDuration]]()
+      }
+
+      "support Period wrapped in Option" in {
+        Option(Period.ofMonths(5)) should haveTypedEncoder[Option[Period]]()
+        Option.empty[Period] should haveTypedEncoder[Option[Period]]()
+      }
+    }
+  }
+}

--- a/src/test/scala/io/github/pashashiz/spark_encoders/OptionEncoderSpec.scala
+++ b/src/test/scala/io/github/pashashiz/spark_encoders/OptionEncoderSpec.scala
@@ -91,7 +91,7 @@ class OptionEncoderSpec extends SparkAnyWordSpec() with TypedEncoderMatchers wit
         // unless we specify the schema explicitly
         val tooBigDecimal = BigDecimal(Long.MaxValue) * 3
         noException should be thrownBy Decimal(tooBigDecimal, SYSTEM_DEFAULT.precision, SYSTEM_DEFAULT.scale)
-        BigDecimal(tooBigDecimal.longValue()) should not equal tooBigDecimal
+        BigDecimal(tooBigDecimal.longValue) should not equal tooBigDecimal
         Option(tooBigDecimal) should haveTypedEncoder[Option[BigDecimal]]()
 
         Option.empty[BigDecimal] should haveTypedEncoder[Option[BigDecimal]]()
@@ -107,7 +107,7 @@ class OptionEncoderSpec extends SparkAnyWordSpec() with TypedEncoderMatchers wit
           .setScale(DecimalType.DEFAULT_SCALE)
           .multiply(new JBigDecimal(3))
         noException should be thrownBy Decimal(tooBigDecimal, SYSTEM_DEFAULT.precision, SYSTEM_DEFAULT.scale)
-        new JBigDecimal(tooBigDecimal.longValue()) should not equal tooBigDecimal
+        new JBigDecimal(tooBigDecimal.longValue) should not equal tooBigDecimal
         Option(tooBigDecimal) should haveTypedEncoder[Option[JBigDecimal]]()
 
         Option.empty[JBigDecimal] should haveTypedEncoder[Option[JBigDecimal]]()

--- a/src/test/scala/io/github/pashashiz/spark_encoders/TypedEncoderSpec.scala
+++ b/src/test/scala/io/github/pashashiz/spark_encoders/TypedEncoderSpec.scala
@@ -379,24 +379,6 @@ class TypedEncoderSpec extends SparkAnyWordSpec() with TypedEncoderMatchers with
         val case3: UserAttribute = UserAttribute.Unknown
         case3 should haveTypedEncoder[UserAttribute]()
       }
-
-      /**
-       * 1. [[Option[Instant]] gets processed by [[OptionEncoder.toCatalyst()]]
-       * 2. [[org.apache.spark.sql.catalyst.expressions.objects.UnwrapOption]] extracts the [[Instant]] from the [[Option]]
-       * 3. [[Primitive.unbox(unwrapped, catalystRepr)]] is called with:
-       *    - unwrapped = the [[Instant]] object
-       *    - catalystRepr = [[TimestampType]] (which is a primitive in Spark)
-       * 4. [[Primitive.isPrimitive(TimestampType)]] returns true
-       * 5. [[org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator.javaType]] converts [[TimestampType]] to [[org.apache.spark.sql.catalyst.types.PhysicalLongType]] and returns "long"
-       * 6. The method name becomes "longValue" 
-       * 7. [[org.apache.spark.sql.catalyst.expressions.objects.Invoke(instant, "longValue", TimestampType)]] is created
-       * 
-       * Note: Spark internally represents timestamps as microseconds since epoch (long values)
-       * via the PhysicalDataType mapping: TimestampType => PhysicalLongType
-       */
-      "support Instant wrapped in Option" in {
-        Option(Instant.now()) should haveTypedEncoder[Option[Instant]]()
-      }
     }
 
     "used with unsupported types" should {

--- a/src/test/scala/io/github/pashashiz/spark_encoders/TypedEncoderSpec.scala
+++ b/src/test/scala/io/github/pashashiz/spark_encoders/TypedEncoderSpec.scala
@@ -394,7 +394,7 @@ class TypedEncoderSpec extends SparkAnyWordSpec() with TypedEncoderMatchers with
        * Note: Spark internally represents timestamps as microseconds since epoch (long values)
        * via the PhysicalDataType mapping: TimestampType => PhysicalLongType
        */
-      "support Instant wrapped in Option" in pendingUntilFixed {
+      "support Instant wrapped in Option" in {
         Option(Instant.now()) should haveTypedEncoder[Option[Instant]]()
       }
     }

--- a/src/test/scala/io/github/pashashiz/spark_encoders/TypedEncoderSpec.scala
+++ b/src/test/scala/io/github/pashashiz/spark_encoders/TypedEncoderSpec.scala
@@ -5,13 +5,13 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
 import org.scalatest.Inside.inside
 
+import scala.util.{Failure, Random, Try}
+import scala.collection.{immutable, mutable}
 import java.math.{BigDecimal => JBigDecimal, BigInteger => JBigInt}
 import java.sql.{Date, Timestamp}
-import java.time._
+import java.time.{Duration, Instant, LocalDate, LocalDateTime, OffsetDateTime, Period, ZonedDateTime}
 import java.util.UUID
-import scala.collection.{immutable, mutable}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
-import scala.util.{Failure, Random, Try}
 
 class TypedEncoderSpec extends SparkAnyWordSpec() with TypedEncoderMatchers with SampleEncoders
     with TypedEncoderImplicits {


### PR DESCRIPTION
Hello,
This PR addresses an issue with the unboxing optimization in `OptionEncoder`.
`OptionEncoder` currently uses Spark's primitive check to determine whether the value is unboxable, but Spark maps some complex types (e.g.: `Instant`) to Java primitives too. For these types, the primitive check returns true, and `OptionEncoder` tries unboxing them, leading to a runtime error (e.g.: no `longValue` method for `Instant`).
The fix in this PR tries to keep as much of the optimization as possible meanwhile making sure these complex types are encoded correctly.