### PR TITLE
Nested objects don't round trip properly

### DIFF
--- a/src/main/scala-2/io/github/pashashiz/spark_encoders/ProductEncoder.scala
+++ b/src/main/scala-2/io/github/pashashiz/spark_encoders/ProductEncoder.scala
@@ -10,6 +10,18 @@ import org.apache.spark.sql.types.{DataType, Metadata, StructField, StructType}
 import scala.reflect.ClassTag
 
 object ProductEncoder {
+
+  /** Recursively make all nested struct fields nullable for UpCast compatibility.
+    * Spark stores nested structs as nullable by default, so when reading back,
+    * we need the target schema to accept nullable struct fields. */
+  def makeNullable(dt: DataType): DataType = dt match {
+    case st: StructType =>
+      StructType(st.fields.map { f =>
+        f.copy(dataType = makeNullable(f.dataType), nullable = true)
+      })
+    case other => other
+  }
+
   def apply[A: ClassTag](ctx: CaseClass[TypedEncoder, A]): TypedEncoder[A] =
     if (ctx.isObject) new CaseObjectEncoder
     else new CaseClassEncoder(ctx)
@@ -68,7 +80,8 @@ class CaseClassEncoder[A: ClassTag](ctx: CaseClass[TypedEncoder, A]) extends Typ
     val exprs = ctx.parameters.map { param =>
       val paramExpr = UpCast(
         child = UnresolvedExtractValue(child = path, extraction = Literal(param.label)),
-        target = param.typeclass.catalystRepr)
+        // Use makeNullable for nested structs since Spark stores them as nullable by default
+        target = ProductEncoder.makeNullable(param.typeclass.catalystRepr))
       // we do not accept null values in Product types,
       // nullable fields should use Option instead
       AssertNotNull(param.typeclass.fromCatalyst(paramExpr))

--- a/src/main/scala-3/io/github/pashashiz/spark_encoders/ProductEncoder.scala
+++ b/src/main/scala-3/io/github/pashashiz/spark_encoders/ProductEncoder.scala
@@ -8,6 +8,19 @@ import io.github.pashashiz.spark_encoders.expressions.ObjectInstance
 
 import scala.reflect.ClassTag
 
+object ProductEncoder:
+  /** Recursively make all nested struct fields nullable for UpCast compatibility.
+    * Spark stores nested structs as nullable by default, so when reading back,
+    * we need the target schema to accept nullable struct fields. */
+  def makeNullable(dt: DataType): DataType = dt match {
+    case st: StructType =>
+      StructType(st.fields.map { f =>
+        f.copy(dataType = makeNullable(f.dataType), nullable = true)
+      })
+    case other => other
+  }
+
+
 class CaseObjectEncoder[A: ClassTag] extends TypedEncoder[A] {
 
   override def catalystRepr: DataType = StructType(Seq.empty)
@@ -66,7 +79,8 @@ class CaseClassEncoder[A: ClassTag](
       case (label, encoder) =>
         val paramExpr = UpCast(
           child = UnresolvedExtractValue(child = path, extraction = Literal(label)),
-          target = encoder.catalystRepr)
+          // Use makeNullable for nested structs since Spark stores them as nullable by default
+          target = ProductEncoder.makeNullable(encoder.catalystRepr))
         // we do not accept null values in Product types,
         // nullable fields should use Option instead
         AssertNotNull(encoder.fromCatalyst(paramExpr))

--- a/src/test/scala/io/github/pashashiz/spark_encoders/NestedObjectSpec.scala
+++ b/src/test/scala/io/github/pashashiz/spark_encoders/NestedObjectSpec.scala
@@ -17,7 +17,7 @@ class NestedObjectSpec extends SparkAnyWordSpec() with TypedEncoderMatchers
             Some(DoubleNext(1.5)))) should haveTypedEncoder[Foo]()
       }
 
-      "work correctly without tuples" in {
+      "work correctly with only nullable nested objects" in {
         Foo2(
           Some("Hello"),
           Some(NestedTwo(

--- a/src/test/scala/io/github/pashashiz/spark_encoders/NestedObjectSpec.scala
+++ b/src/test/scala/io/github/pashashiz/spark_encoders/NestedObjectSpec.scala
@@ -20,10 +20,10 @@ class NestedObjectSpec extends SparkAnyWordSpec() with TypedEncoderMatchers
       "work correctly without tuples" in {
         Foo2(
           Some("Hello"),
-          NestedTwo(
-            NestedObject(
-              Some("Hello!")),
-            DoubleNext(1.5))) should haveTypedEncoder[Foo2]()
+          Some(NestedTwo(
+            Some(NestedObject(
+              Some("Hello!"))),
+            Some(DoubleNext(1.5)))))   should haveTypedEncoder[Foo2]()
       }
     }
   }
@@ -35,6 +35,6 @@ object NestedObjectSpec {
   case class DoubleNext(value: Double)
   case class Foo(str: Option[String], nestedObject: (NestedObject, Option[DoubleNext]))
 
-  case class NestedTwo(obj: NestedObject, double: DoubleNext)
-  case class Foo2(str: Option[String], nestedObject: NestedTwo)
+  case class NestedTwo(obj: Option[NestedObject], doubleNezt: Option[DoubleNext])
+  case class Foo2(str: Option[String], nestedObject: Option[NestedTwo])
 }

--- a/src/test/scala/io/github/pashashiz/spark_encoders/NestedObjectSpec.scala
+++ b/src/test/scala/io/github/pashashiz/spark_encoders/NestedObjectSpec.scala
@@ -1,0 +1,40 @@
+package io.github.pashashiz.spark_encoders
+import NestedObjectSpec._
+
+class NestedObjectSpec extends SparkAnyWordSpec() with TypedEncoderMatchers
+    with TypedEncoderImplicits {
+
+  "NestedObject" when {
+
+    "used with complex types" should {
+
+      "work correctly" in {
+        Foo(
+          Some("Hello"),
+          (
+            NestedObject(
+              Some("Hello!")),
+            Some(DoubleNext(1.5)))) should haveTypedEncoder[Foo]()
+      }
+
+      "work correctly without tuples" in {
+        Foo2(
+          Some("Hello"),
+          NestedTwo(
+            NestedObject(
+              Some("Hello!")),
+            DoubleNext(1.5))) should haveTypedEncoder[Foo2]()
+      }
+    }
+  }
+}
+
+object NestedObjectSpec {
+
+  case class NestedObject(value: Option[String])
+  case class DoubleNext(value: Double)
+  case class Foo(str: Option[String], nestedObject: (NestedObject, Option[DoubleNext]))
+
+  case class NestedTwo(obj: NestedObject, double: DoubleNext)
+  case class Foo2(str: Option[String], nestedObject: NestedTwo)
+}


### PR DESCRIPTION
I think spark defaults all nested relations to nullable, so as you can see before the fix both those tests would break.  Now they work with some nulling magic