### PR TITLE
Fixed nested tuples

### DIFF
--- a/.idea/sbt.xml
+++ b/.idea/sbt.xml
@@ -11,6 +11,7 @@
             <option value="$PROJECT_DIR$/project" />
           </set>
         </option>
+        <option name="sbtVersion" value="1.11.0" />
         <option name="useSbtShellForBuild" value="true" />
         <option name="useSbtShellForImport" value="true" />
       </SbtProjectSettings>

--- a/src/main/scala-2/io/github/pashashiz/spark_encoders/ProductEncoder.scala
+++ b/src/main/scala-2/io/github/pashashiz/spark_encoders/ProductEncoder.scala
@@ -60,8 +60,10 @@ class CaseClassEncoder[A: ClassTag](ctx: CaseClass[TypedEncoder, A]) extends Typ
       case (nameExpr, valueExpr) => nameExpr :: valueExpr :: Nil
     }
     val createExpr = CreateNamedStruct(exprs)
-    val nullExpr = Literal.create(null, createExpr.dataType)
-    If(IsNull(path), nullExpr, createExpr)
+    if (path.nullable)
+      If(IsNull(path), Literal.create(null, createExpr.dataType), createExpr)
+    else
+      createExpr
   }
 
   override def fromCatalyst(path: Expression): Expression = {
@@ -78,8 +80,7 @@ class CaseClassEncoder[A: ClassTag](ctx: CaseClass[TypedEncoder, A]) extends Typ
       arguments = exprs,
       dataType = jvmRepr,
       propagateNull = true)
-    val nullExpr = Literal.create(null, jvmRepr)
-    If(IsNull(path), nullExpr, newExpr)
+    If(IsNull(path), Literal.create(null, jvmRepr), newExpr)
   }
 
   override def toString: String = s"CaseClassEncoder($jvmRepr)"

--- a/src/main/scala-3/io/github/pashashiz/spark_encoders/ProductEncoder.scala
+++ b/src/main/scala-3/io/github/pashashiz/spark_encoders/ProductEncoder.scala
@@ -57,8 +57,10 @@ class CaseClassEncoder[A: ClassTag](
       case (nameExpr, valueExpr) => nameExpr :: valueExpr :: Nil
     }
     val createExpr = CreateNamedStruct(exprs)
-    val nullExpr = Literal.create(null, createExpr.dataType)
-    If(IsNull(path), nullExpr, createExpr)
+    if (path.nullable)
+      If(IsNull(path), Literal.create(null, createExpr.dataType), createExpr)
+    else
+      createExpr
   }
 
   override def fromCatalyst(path: Expression): Expression = {
@@ -76,8 +78,7 @@ class CaseClassEncoder[A: ClassTag](
       arguments = exprs,
       dataType = jvmRepr,
       propagateNull = true)
-    val nullExpr = Literal.create(null, jvmRepr)
-    If(IsNull(path), nullExpr, newExpr)
+    If(IsNull(path), Literal.create(null, jvmRepr), newExpr)
   }
 
   override def toString: String = s"CaseClassEncoder($jvmRepr)"

--- a/src/test/scala/io/github/pashashiz/spark_encoders/SampleEncoders.scala
+++ b/src/test/scala/io/github/pashashiz/spark_encoders/SampleEncoders.scala
@@ -13,6 +13,7 @@ case class UserOptBoth(name: Option[String], age: Option[Int])
 
 case class SimpleTask(name: String, user: SimpleUser)
 case class SimpleTaskOptUser(name: String, user: Option[SimpleUser])
+case class SimpleTaskTuple(fields: (String, SimpleUser))
 
 sealed trait WorkItem {
   def name: String
@@ -112,6 +113,8 @@ trait SampleEncoders {
   implicit def simpleTaskEncoder: TypedEncoder[SimpleTask] = derive[SimpleTask]
   implicit def simpleTaskOptUserEncoder: TypedEncoder[SimpleTaskOptUser] =
     derive[SimpleTaskOptUser]
+  implicit def simpleTaskWrapperEncoder: TypedEncoder[SimpleTaskTuple] =
+    derive[SimpleTaskTuple]
   implicit def workItemEncoder: TypedEncoder[WorkItem] = derive[WorkItem]
   implicit def workItemDiffTypeEncoder: TypedEncoder[WorkItemDiffType] =
     derive[WorkItemDiffType]

--- a/src/test/scala/io/github/pashashiz/spark_encoders/TypedEncoderSpec.scala
+++ b/src/test/scala/io/github/pashashiz/spark_encoders/TypedEncoderSpec.scala
@@ -208,6 +208,11 @@ class TypedEncoderSpec extends SparkAnyWordSpec() with TypedEncoderMatchers with
         SimpleTaskOptUser("t1", None) should haveTypedEncoder[SimpleTaskOptUser]()
       }
 
+      "support nested tuples" in {
+        SimpleTaskTuple(("task", SimpleUser("Pablo", 34))) should
+          haveTypedEncoder[SimpleTaskTuple]()
+      }
+
       "gracefully fail when null value used as nested product" in {
         SimpleTaskOptUser("t1", null) should failToSerializeWith[SimpleTaskOptUser](
           _.toLowerCase().contains("null value appeared in non-nullable field")


### PR DESCRIPTION
Turned out nested tuples were failing with cast exception due to the fact that `toCatalyst` would always return nullable object. That was revealed by https://github.com/pashashiz/spark-encoders/pull/18. This PR takes simpler approach to fix it and simply makes catalyst expression compatible with data type.